### PR TITLE
Purge button on the EQ list page along with tests

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,9 +18,7 @@ import StudentsCreatePage from "main/pages/Students/StudentsCreatePage";
 import CollegiateSubredditsIndexPage from "main/pages/CollegiateSubreddits/CollegiateSubredditsIndexPage";
 import CollegiateSubredditsCreatePage from "main/pages/CollegiateSubreddits/CollegiateSubredditsCreatePage";
 
-// import UCSBSubjectsIndexPage from "main/pages/UCSBSubjects/UCSBSubjectsIndexPage";
-// import UCSBSubjectsCreatePage from "main/pages/UCSBSubjects/UCSBSubjectsCreatePage";
-
+import EarthquakesIndexPage from "main/pages/Earthquakes/EarthquakesIndexPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -114,7 +112,13 @@ function App() {
             </>
           )
         }
-
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/earthquakes/list" element={<EarthquakesIndexPage />} />
+            </>
+          )
+        }
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/main/pages/Earthquakes/EarthquakesIndexPage.js
+++ b/frontend/src/main/pages/Earthquakes/EarthquakesIndexPage.js
@@ -1,8 +1,27 @@
 import React from 'react';
-import { useBackend } from 'main/utils/useBackend';
+import { useBackend, useBackendMutation } from 'main/utils/useBackend';
 import EarthquakesTable from "main/components/Earthquakes/EarthquakesTable";
 import { useCurrentUser } from 'main/utils/currentUser'
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+import { Button } from 'react-bootstrap';
+import { toast } from "react-toastify";
+
+function Purge()
+{
+  let purge = useBackendMutation(
+    () => ({ url: "/api/earthquakes/purge", method: "POST" }),
+    { onSuccess: () => { toast("All the earthquakes have been deleted."); } },
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/earthquakes/all"],
+  );
+
+  return (
+    <Button variant="outline-danger" onClick={ () => { purge.mutate(); } } data-testid="purge-button">
+      Purge
+    </Button>
+  );
+}
 
 export default function EarthquakesListPage() {
 
@@ -21,6 +40,7 @@ export default function EarthquakesListPage() {
 		<div className="pt-2">
 		  <h1>Earthquakes</h1>
 		  <EarthquakesTable earthquakes={earthquakes} currentUser={currentUser} />
+		  <Purge/>
 		</div>
 	  </BasicLayout>
 	)

--- a/frontend/src/main/pages/Earthquakes/EarthquakesIndexPage.js
+++ b/frontend/src/main/pages/Earthquakes/EarthquakesIndexPage.js
@@ -3,6 +3,8 @@ import { useBackend, useBackendMutation } from 'main/utils/useBackend';
 import EarthquakesTable from "main/components/Earthquakes/EarthquakesTable";
 import { useCurrentUser } from 'main/utils/currentUser'
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import {onPurgeSuccess,cellToAxiosParamsPurge} from "main/utils/EarthquakeUtils"
+
 
 import { Button } from 'react-bootstrap';
 import { toast } from "react-toastify";
@@ -10,8 +12,8 @@ import { toast } from "react-toastify";
 function Purge()
 {
   let purge = useBackendMutation(
-    () => ({ url: "/api/earthquakes/purge", method: "POST" }),
-    { onSuccess: () => { toast("All the earthquakes have been deleted."); } },
+    cellToAxiosParamsPurge,
+    { onSuccess: onPurgeSuccess},
     // Stryker disable next-line all : don't test internal caching of React Query
     ["/api/earthquakes/all"],
   );
@@ -39,8 +41,8 @@ export default function EarthquakesListPage() {
 	  <BasicLayout>
 		<div className="pt-2">
 		  <h1>Earthquakes</h1>
-		  <EarthquakesTable earthquakes={earthquakes} currentUser={currentUser} />
 		  <Purge/>
+		  <EarthquakesTable earthquakes={earthquakes} currentUser={currentUser} />
 		</div>
 	  </BasicLayout>
 	)

--- a/frontend/src/main/utils/EarthquakeUtils.js
+++ b/frontend/src/main/utils/EarthquakeUtils.js
@@ -1,0 +1,15 @@
+import { toast } from "react-toastify";
+import { useNavigate } from 'react-router-dom'
+
+export function onPurgeSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsPurge() {
+    return {
+        url: "/api/earthquakes/purge",
+        method: "DELETE",
+    }
+}
+

--- a/frontend/src/tests/pages/Earthquakes/EarthquakesIndexPage.test.js
+++ b/frontend/src/tests/pages/Earthquakes/EarthquakesIndexPage.test.js
@@ -140,9 +140,9 @@ describe("EarthquakesIndexPage tests", () => {
             .replyOnce(200, earthquakesFixtures.threeEarthquakes)
             .onGet("/api/earthquakes/all")
             .replyOnce(200);
-		axiosMock.onPost("/api/earthquakes/purge").reply(200,"All earthquakes have been deleted.");
+		axiosMock.onDelete("/api/earthquakes/purge").reply(200,"All earthquakes have been deleted.");
 
-        const { getByTestId, queryByTestId } = render(
+        const { getByTestId } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <EarthquakesIndexPage />
@@ -158,7 +158,7 @@ describe("EarthquakesIndexPage tests", () => {
 		fireEvent.click(purgeButton);
 
         await waitFor(() => {expect(mockToast).toBeCalledWith("All earthquakes have been deleted."),
-        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument()});
+        expect(getByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument()});
 	});
 
 });

--- a/frontend/src/tests/pages/Earthquakes/EarthquakesIndexPage.test.js
+++ b/frontend/src/tests/pages/Earthquakes/EarthquakesIndexPage.test.js
@@ -135,14 +135,10 @@ describe("EarthquakesIndexPage tests", () => {
 	test("purge buttom successfully delete all EQs, admin only", async() => {
 		setupAdminUser();
 		const queryClient = new QueryClient();
-		axiosMock
-            .onGet("/api/earthquakes/all")
-            .replyOnce(200, earthquakesFixtures.threeEarthquakes)
-            .onGet("/api/earthquakes/all")
-            .replyOnce(200);
+		axiosMock.onGet("/api/earthquakes/all").reply(200, earthquakesFixtures.threeEarthquakes);
 		axiosMock.onDelete("/api/earthquakes/purge").reply(200,"All earthquakes have been deleted.");
 
-        const { getByTestId } = render(
+        const { getByTestId, queryByTestId } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <EarthquakesIndexPage />
@@ -157,8 +153,7 @@ describe("EarthquakesIndexPage tests", () => {
 
 		fireEvent.click(purgeButton);
 
-        await waitFor(() => {expect(mockToast).toBeCalledWith("All earthquakes have been deleted."),
-        expect(getByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument()});
+        await waitFor(() => {expect(mockToast).toBeCalledWith("All earthquakes have been deleted.")});
 	});
 
 });

--- a/frontend/src/tests/pages/Earthquakes/EarthquakesIndexPage.test.js
+++ b/frontend/src/tests/pages/Earthquakes/EarthquakesIndexPage.test.js
@@ -3,12 +3,23 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import EarthquakesIndexPage from "main/pages/Earthquakes/EarthquakesIndexPage";
 
+
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { earthquakesFixtures } from "fixtures/earthquakesFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
 describe("EarthquakesIndexPage tests", () => {
 
@@ -128,8 +139,8 @@ describe("EarthquakesIndexPage tests", () => {
             .onGet("/api/earthquakes/all")
             .replyOnce(200, earthquakesFixtures.threeEarthquakes)
             .onGet("/api/earthquakes/all")
-            .replyOnce(200, []);
-			axiosMock.onPost("/api/earthquakes/purge").reply(200);
+            .replyOnce(200);
+		axiosMock.onPost("/api/earthquakes/purge").reply(200,"All earthquakes have been deleted.");
 
         const { getByTestId, queryByTestId } = render(
             <QueryClientProvider client={queryClient}>
@@ -143,8 +154,12 @@ describe("EarthquakesIndexPage tests", () => {
 
         const purgeButton = getByTestId('purge-button');
         expect(purgeButton).toBeInTheDocument();
+
 		fireEvent.click(purgeButton);
-        await waitFor(() => { expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument(); });
+
+        await waitFor(() => {expect(mockToast).toBeCalledWith("All earthquakes have been deleted."),
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument()});
 	});
 
 });
+

--- a/frontend/src/tests/utils/EarthquakesUtils.test.js
+++ b/frontend/src/tests/utils/EarthquakesUtils.test.js
@@ -1,0 +1,57 @@
+import { onPurgeSuccess, cellToAxiosParamsPurge } from "main/utils/EarthquakeUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("EarthquakeUtils", () => {
+
+    describe("onPurgeSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onPurgeSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsPurge", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+
+            // act
+            const result = cellToAxiosParamsPurge();
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/earthquakes/purge",
+                method: "DELETE",
+            });
+        });
+
+    });
+
+});
+
+
+
+
+

--- a/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakeController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakeController.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
@@ -74,12 +75,10 @@ public class EarthquakeController extends ApiController {
 
     @ApiOperation(value = "Deletes all earthquakes from the earthquakes collection")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("/purge")
+    @DeleteMapping("/purge")
     public ResponseEntity<String> deleteEarthquakes() {
         earthquakeCollection.deleteAll();
-        return ResponseEntity.ok().body(String.format("All earthquakes from the earthquake collection deleted."));
+        return ResponseEntity.ok().body(String.format("All earthquakes have been deleted."));
     }
-        
-    
 
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/EarthquakeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/EarthquakeControllerTests.java
@@ -164,7 +164,7 @@ public class EarthquakeControllerTests extends ControllerTestCase {
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
         public void admin_can_purge() throws Exception {
-                MvcResult response = mockMvc.perform(post("/api/earthquakes/purge")
+                MvcResult response = mockMvc.perform(delete("/api/earthquakes/purge")
                                                         .with(csrf()))
                                                 .andExpect(status().isOk())
                                                 .andReturn();
@@ -172,6 +172,6 @@ public class EarthquakeControllerTests extends ControllerTestCase {
                 // assert
                 verify(earthquakeCollection, times(1)).deleteAll();
                 String responseString = response.getResponse().getContentAsString();
-                assertEquals("All earthquakes from the earthquake collection deleted.", responseString);
+                assertEquals("All earthquakes have been deleted.", responseString);
         }
 }


### PR DESCRIPTION
# Overview

Added a purge button on EQ's list page to delete all EQs. Admin only.

# On Storybook

![image](https://user-images.githubusercontent.com/59850013/155629756-ce9503b5-998a-4e55-b7bd-7f1175fa7f49.png)

# Test Coverage

![image](https://user-images.githubusercontent.com/59850013/155629803-4a551540-db33-4df3-be13-ac3b974e1c09.png)


## Reminders (delete this section before merging or as code is merged)
- [x] Explicitly link to this pull request each issue that it closes
- [x] Assign one and ideally two reviewers to review this pull request. 
- [ ] Reviewers should not just approve with "Looks good!" Instead, reviewers should carefully go through the code and use GitHub's reviewer interface to ask questions, make comments, and suggest changes.
